### PR TITLE
Fix proto path again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@edgepi-cloud/rpc-protobuf": "^1.0.2",
+        "@edgepi-cloud/rpc-protobuf": "^1.0.9",
         "@types/node": "^20.4.2",
         "protobufjs": "^7.2.4",
         "protobufjs-cli": "^1.1.1",
@@ -620,8 +620,9 @@
       "license": "MIT"
     },
     "node_modules/@edgepi-cloud/rpc-protobuf": {
-      "version": "1.0.2",
-      "license": "MIT"
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@edgepi-cloud/rpc-protobuf/-/rpc-protobuf-1.0.9.tgz",
+      "integrity": "sha512-I8aYupddDa23L9ZvHegvqMZoBKpaA2aavCBPfHe5RyeV11Zek1qPYSvAfw+LLn0CTbsdtvo7NJEWmFwVQ7XuRQ=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@edgepi-cloud/rpc-protobuf": "^1.0.2",
+    "@edgepi-cloud/rpc-protobuf": "^1.0.9",
     "@types/node": "^20.4.2",
     "protobufjs": "^7.2.4",
     "protobufjs-cli": "^1.1.1",

--- a/src/services/DoutService/DoutPins.ts
+++ b/src/services/DoutService/DoutPins.ts
@@ -1,7 +1,7 @@
 import * as protobuf from 'protobufjs'
 import path from 'path';
 
-const protoPckgPath = path.join(process.cwd(), 'node_modules', '@edgepi-cloud', 'rpc-protobuf');
+const protoPckgPath = path.join(require.resolve('@edgepi-cloud/rpc-protobuf'), '..');
 
 const root = protobuf.loadSync(path.join(protoPckgPath, 'dout.proto'))
 const protoEnum = root.lookupEnum('DoutPins').values

--- a/src/services/DoutService/DoutService.ts
+++ b/src/services/DoutService/DoutService.ts
@@ -5,7 +5,7 @@ import type { serverResponse, serviceRequest } from '../../rpcChannel/ReqRepType
 import { SuccessMsg } from './DoutTypes'
 
 // Construct the path to the proto pacakge directory
-const protoPckgPath = path.join(process.cwd(), 'node_modules', '@edgepi-cloud', 'rpc-protobuf');
+const protoPckgPath = path.join(require.resolve('@edgepi-cloud/rpc-protobuf'), '..');
 
   /**
    * @constructor DoutService class for calling EdgePi digital output SDK methods through RPC

--- a/src/services/LedService/LedPins.ts
+++ b/src/services/LedService/LedPins.ts
@@ -2,7 +2,7 @@ import * as protobuf from 'protobufjs'
 import path from 'path'
 
 // Construct the path to the proto pacakge directory
-const protoPckgPath = path.join(process.cwd(), 'node_modules', '@edgepi-cloud', 'rpc-protobuf');
+const protoPckgPath = path.join(require.resolve('@edgepi-cloud/rpc-protobuf'),'..');
 
 const root = protobuf.loadSync(path.join(protoPckgPath, 'led.proto'))
 const protoEnum = root.lookupEnum('LEDPins').values

--- a/src/services/LedService/LedService.ts
+++ b/src/services/LedService/LedService.ts
@@ -4,8 +4,7 @@ import { RpcChannel } from '../../rpcChannel/RpcChannel'
 import type { serverResponse, serviceRequest } from '../../rpcChannel/ReqRepTypes'
 import { LEDPin, SuccessMsg } from './LedTypes'
 
-
-const protoPckgPath = path.join(process.cwd(), 'node_modules', '@edgepi-cloud', 'rpc-protobuf');
+const protoPckgPath = path.join(require.resolve('@edgepi-cloud/rpc-protobuf'), '..');
 
 /**
  * @constructor LEDService class for calling EdgePi LED SDK methods through RPC

--- a/src/services/TcService/TcService.ts
+++ b/src/services/TcService/TcService.ts
@@ -4,7 +4,7 @@ import { RpcChannel } from '../../rpcChannel/RpcChannel'
 import type { serverResponse, serviceRequest } from '../../rpcChannel/ReqRepTypes'
 import type { TempReading } from './tcTypes'
 
-const protoPckgPath = path.join(process.cwd(), 'node_modules', '@edgepi-cloud', 'rpc-protobuf');
+const protoPckgPath = path.join(require.resolve('@edgepi-cloud/rpc-protobuf'), '..')
 
   /**
    * @constructor TcService class for calling EdgePi thermocouple SDK methods through RPC


### PR DESCRIPTION
#30  was wrong because it only worked if someone ran the client script (or node-red) from an environment with a 'node_modules' folder in the parent. This solution will always resolve where the protobuf module is no matter where your program is run.